### PR TITLE
Added FAQ section to README

### DIFF
--- a/Fallout2/Fallout1in2/README.md
+++ b/Fallout2/Fallout1in2/README.md
@@ -39,6 +39,10 @@ MOD INSTALLATION
 
 That's it. The game can now be played!
 
+***Note:*** Some digital releases of Fallout 2 use a non-default location for the music tracks. If you notice missing music during gameplay, do the following:
+Check where `/music/` in your Fallout 2 installation folder is. Then open the `fallout2.cfg` file of `Fallout1in2` and change the path under 
+`music_path2` accordingly. Or copy all the Fallout 2 music files into the `/Fallout2/Fallout1in2/sounds/music/` folder. That will work as well.
+
 
 CONFIGURATION
 -------------
@@ -48,19 +52,6 @@ Main mod configuration can be found in [config/fo1_settings.ini](config/fo1_sett
 Other interesting files:
 - [ddraw.ini](ddraw.ini) (sfall configuration)
 - [sfall-mods.ini](sfall-mods.ini), [config/](config/) directory (sfall modifications configuration)
-
-
-FAQ
--------------
-
-#### Some of the music tracks aren't playing! ####
-Check where `/music/` in your Fallout 2 installation folder is. Then open the `fallout2.cfg` file of `Fallout1in2` and change the path under 
-`music_path2` accordingly. Or copy all the Fallout 2 music files into the `/Fallout2/Fallout1in2/sounds/music/` folder. That will work as well.
-
-#### The game crashes while showing the splash screen! ####
-If you use non-english game versions for the installation of this mod, you must set `fallout2.cfg` to the corresponding
-language. For example, when using the german versions of Fallout 1 and 2, set `language=german` in `/Fallout2/Fallout1in2/fallout2.cfg`.
-
 
 ADDITIONAL CONTENT
 ------------------

--- a/Fallout2/Fallout1in2/README.md
+++ b/Fallout2/Fallout1in2/README.md
@@ -7,11 +7,13 @@ Fallout et tu (also called Fallout 1@2, 1at2, 1in2, ...) is bringing the first F
 
 ---
 
-Discussion: https://nma-fallout.com/threads/218045/ (release, beta),
-            https://nma-fallout.com/threads/217892/ (alpha),
-            https://nma-fallout.com/threads/179809/ (legacy)
+Discussion
+- https://nma-fallout.com/threads/218045/ (release, beta)
+- https://nma-fallout.com/threads/217892/ (alpha)
+- https://nma-fallout.com/threads/179809/ (legacy)
 
-Repository: https://github.com/rotators/Fo1in2/
+Repository
+- https://github.com/rotators/Fo1in2/
 
 
 MOD INSTALLATION
@@ -39,9 +41,10 @@ MOD INSTALLATION
 
 That's it. The game can now be played!
 
-***Note:*** Some digital releases of Fallout 2 use a non-default location for the music tracks. If you notice missing music during gameplay, do the following:
-Check where `/music/` in your Fallout 2 installation folder is. Then open the `fallout2.cfg` file of `Fallout1in2` and change the path under 
-`music_path2` accordingly. Or copy all the Fallout 2 music files into the `/Fallout2/Fallout1in2/sounds/music/` folder. That will work as well.
+### Missing music ###
+Some digital releases of Fallout 2 use a non-default location for the music tracks; if you notice missing music during gameplay, you have two options:
+- Check where `music/` in your Fallout 2 installation folder is and change `Fallout1in2/Fallout2.cfg` setting `[sound]->music_path2` accordingly.
+- Copy all the Fallout 2 music files into the `Fallout1in2/data/sound/music/` folder.
 
 
 CONFIGURATION
@@ -52,6 +55,7 @@ Main mod configuration can be found in [config/fo1_settings.ini](config/fo1_sett
 Other interesting files:
 - [ddraw.ini](ddraw.ini) (sfall configuration)
 - [sfall-mods.ini](sfall-mods.ini), [config/](config/) directory (sfall modifications configuration)
+
 
 ADDITIONAL CONTENT
 ------------------
@@ -86,7 +90,7 @@ Tweaks the costs of specific actions while using inventory.
 ### Language Pack - German ###
 [mods/fo1_german](mods/fo1_german)
 
-The german translation of FALLOUT ET TU.
+The german translation of FALLOUT ET TU. It's highly recommended to check README in language pack directory.
 
 ### Robodog ###
 [mods/fo1_robodog](mods/fo1_robodog)

--- a/Fallout2/Fallout1in2/README.md
+++ b/Fallout2/Fallout1in2/README.md
@@ -50,6 +50,21 @@ Other interesting files:
 - [sfall-mods.ini](sfall-mods.ini), [config/](config/) directory (sfall modifications configuration)
 
 
+FAQ
+-------------
+
+#### Some of the music tracks aren't playing! ####
+Check where `/music/` in your Fallout 2 installation folder is. Then open the `fallout2.cfg` file of `Fallout1in2` and change the path under 
+`music_path2` accordingly. Or copy all the Fallout 2 music files into the `/Fallout2/Fallout1in2/sounds/music/` folder. That will work as well.
+
+#### I'm playing in 640x480px resolution and my buttons are all messed up! ####
+Uncomment `PipBoyNoteOffset` in the `fo1_settings.ini` file. Otherwise the PipBoy water timer note will be misaligned.
+
+#### The game crashes while showing the splash screen! ####
+If you use non-english game versions for the installation of this mod, you must set `fallout2.cfg` to the corresponding
+language. For example, when using the german versions of Fallout 1 and 2, set `language=german` in `/Fallout2/Fallout1in2/fallout2.cfg`.
+
+
 ADDITIONAL CONTENT
 ------------------
 

--- a/Fallout2/Fallout1in2/README.md
+++ b/Fallout2/Fallout1in2/README.md
@@ -57,9 +57,6 @@ FAQ
 Check where `/music/` in your Fallout 2 installation folder is. Then open the `fallout2.cfg` file of `Fallout1in2` and change the path under 
 `music_path2` accordingly. Or copy all the Fallout 2 music files into the `/Fallout2/Fallout1in2/sounds/music/` folder. That will work as well.
 
-#### I'm playing in 640x480px resolution and my buttons are all messed up! ####
-Uncomment `PipBoyNoteOffset` in the `fo1_settings.ini` file. Otherwise the PipBoy water timer note will be misaligned.
-
 #### The game crashes while showing the splash screen! ####
 If you use non-english game versions for the installation of this mod, you must set `fallout2.cfg` to the corresponding
 language. For example, when using the german versions of Fallout 1 and 2, set `language=german` in `/Fallout2/Fallout1in2/fallout2.cfg`.

--- a/Fallout2/Fallout1in2/mods/fo1_german/README.md
+++ b/Fallout2/Fallout1in2/mods/fo1_german/README.md
@@ -5,11 +5,12 @@ Fallout 1 Language Pack - German / Deutsch
 
 Die deutsche Übersetzung von FALLOUT ET TU.
 
-Das Spiel ist im Großen und Ganzen auf Deutsch spielbar, allerdings lassen sich noch die ein oder anderen englischen Sätze finden.
-Jede Hilfe bei der Fertigstellung der Übersetzung ist willkommen!
+Das Spiel sollte komplett auf Deutsch spielbar sein. Falls sich doch noch die ein oder anderen englischen Passagen finden lassen,
+ist jede Hilfe bei der Fertigstellung der Übersetzung willkommen!
 
 ### Installation
-Um mit dieser Mod spielen zu können, öffne die ddraw.ini, gehe zu [ExtraPatches] und füge "PatchFile[number]=mods\fo1_german" ans Ende der "PatchFile"-Liste!
+Zuerst sollte sichergestellt sein, dass in `fallout2.cfg` die Sprache auf Deutsch eingestellt ist (`language=german`).
+Öffne dann die `ddraw.ini`, gehe zu `[ExtraPatches]` und füge `PatchFile[number]=mods\fo1_german` ans Ende der `PatchFile`-Liste!
 Das Spiel wird dann die Mod laden.
 
-Falls mehr als eine Mod geladen wird, muss darauf geachtet werden, dass "PatchFileX" korrekt nummeriert wird (1, 2, 3, ...).
+Falls mehr als eine Mod geladen wird, muss darauf geachtet werden, dass `PatchFileX` korrekt nummeriert wird (1, 2, 3, ...).


### PR DESCRIPTION
I think it may be a good idea to add some parts from the FAQ section at NMA forums to the README.
I've also included info about a potential crash due to a wrong language setting (discussed [here](https://github.com/rotators/Fo1in2/issues/64))
