### PR TITLE
fix `dat2.exe` path

### DIFF
--- a/Tools/UndatCLI/undat.sh
+++ b/Tools/UndatCLI/undat.sh
@@ -16,7 +16,7 @@ fi
 
 root_dir="$(dirname $0)"
 data_dir="$root_dir/data"
-dat2="wine $root_dir/dat2.exe"
+dat2="wine $root_dir/../Fallout2_ProtoManager/dat2.exe"
 undat_list="$root_dir/undat_files.txt"
 
 if ! $dat2 l $master_dat > /dev/null 2>&1; then


### PR DESCRIPTION
the linux script wasn't working anymore because it couldn't find `dat2.exe`. It seems it has been moved. with that fix unpacker seems to work again. at least I got this response:
```shell
Fallout DAT-files packer/unpacker, version 2.32
Copyright (C) Anchorite (TeamX), 2004-2006
anchorite2001@yandex.ru

   Length      Packed     Type   Name
 ---------- ----------- -------- ---------------
      33536        9292  Packed  COLOR.PAL
       6337        2316  Packed  FONT0.AAF
       3044        1459  Packed  FONT0.FON
      12844        3102  Packed  FONT1.AAF
       2044        1014  Packed  FONT1.FON
      25395        6849  Packed  FONT2.AAF
      [...]
       6371        3099  Packed  TEXT\SPANISH\GAME\PROTO.MSG
        120         115  Packed  TEXT\SPANISH\GAME\SCRIPT.MSG
      66503       19364  Packed  TEXT\SPANISH\GAME\SCRNAME.MSG
       4454        2403  Packed  TEXT\SPANISH\GAME\SKILL.MSG
        219         172  Packed  TEXT\SPANISH\GAME\SKILLDEX.MSG
       6034        2673  Packed  TEXT\SPANISH\GAME\STAT.MSG
       3242        1958  Packed  TEXT\SPANISH\GAME\TRAIT.MSG
       1680         895  Packed  TEXT\SPANISH\GAME\WORLDMAP.MSG
 ----------                      ---------------
  477089046                        19784 file(s)

Flushing buffers...
Fallout DAT-files packer/unpacker, version 2.32
Copyright (C) Anchorite (TeamX), 2004-2006
anchorite2001@yandex.ru

Error: Unable open response file

```