### PR TITLE
Fix lockpicks not being removed on critical failure

### DIFF
--- a/Fallout2/Fallout1in2/Mapper/source/scripts.backup/99unknown/GLOWGN.ssl
+++ b/Fallout2/Fallout1in2/Mapper/source/scripts.backup/99unknown/GLOWGN.ssl
@@ -151,8 +151,8 @@ begin
 			else begin
 				if (is_critical(LVar2)) then begin
 					display_msg(message_str(SCRIPT_GLOBLDOR, 121));
-					rm_obj_from_inven(source_obj, LVar0);
-					destroy_object(LVar0);
+					rm_obj_from_inven(source_obj, obj_being_used_with);
+					destroy_object(obj_being_used_with);
 				end
 				else begin
 					display_msg(message_str(SCRIPT_GLOBLDOR, 122));
@@ -925,4 +925,3 @@ begin
 		end
 	end
 end
-

--- a/Fallout2/Fallout1in2/Mapper/source/scripts/05necropolis/HALLDOOR.ssl
+++ b/Fallout2/Fallout1in2/Mapper/source/scripts/05necropolis/HALLDOOR.ssl
@@ -257,8 +257,8 @@ procedure use_obj_on_p_proc begin
          else begin
             // Lockpicks broken:
             if (is_critical(Skills_Roll)) then begin
-               rm_obj_from_inven(dude_obj, Tool);
-               destroy_object(Tool);
+               rm_obj_from_inven(dude_obj, obj_being_used_with);
+               destroy_object(obj_being_used_with);
                display_msg(mstr(101));
             end
             // Not able to open the door:

--- a/Fallout2/Fallout1in2/Mapper/source/scripts/05necropolis/SETDOOR.ssl
+++ b/Fallout2/Fallout1in2/Mapper/source/scripts/05necropolis/SETDOOR.ssl
@@ -251,8 +251,8 @@ begin
                end
                else begin
                   if (is_critical(LVar2)) then begin
-                     rm_obj_from_inven(dude_obj, LVar0);
-                     destroy_object(LVar0);
+                     rm_obj_from_inven(dude_obj, obj_being_used_with);
+                     destroy_object(obj_being_used_with);
                      jam_lock(self_obj);
                      display_msg(mstr(109));
                   end

--- a/Fallout2/Fallout1in2/Mapper/source/scripts/09glow/GLOYLDOR.ssl
+++ b/Fallout2/Fallout1in2/Mapper/source/scripts/09glow/GLOYLDOR.ssl
@@ -155,8 +155,8 @@ procedure use_obj_on_p_proc begin
                display_msg(self_mstr(121));
                jam_lock(self_obj);
                display_msg(message_str(SCRIPT_DOOR, 110));
-               rm_obj_from_inven(source_obj, Item);
-               destroy_object(Item);
+               rm_obj_from_inven(source_obj, obj_being_used_with);
+               destroy_object(obj_being_used_with);
             end
             else begin
                display_msg(self_mstr(122));


### PR DESCRIPTION
This places tries to remove pids instead of objects