### PR TITLE
Fix check for lockpicks mk ii

### DIFF
--- a/Fallout2/Fallout1in2/Mapper/source/scripts/07bos/BHDOOR.ssl
+++ b/Fallout2/Fallout1in2/Mapper/source/scripts/07bos/BHDOOR.ssl
@@ -93,7 +93,7 @@ procedure use_obj_on_p_proc begin
    if (obj_pid(Tool) == PID_ELECTRONIC_LOCKPICKS or obj_pid(Tool) == PID_ELEC_LOCKPICK_MKII) then begin
       script_overrides;
 
-      if (Tool == PID_ELEC_LOCKPICK_MKII) then
+      if (obj_pid(Tool) == PID_ELEC_LOCKPICK_MKII) then
          Skill := roll_vs_skill(dude_obj, SKILL_LOCKPICK, -40);
 
       if (is_success(Skill)) then begin

--- a/Fallout2/Fallout1in2/Mapper/source/scripts/07bos/SUPDOOR.ssl
+++ b/Fallout2/Fallout1in2/Mapper/source/scripts/07bos/SUPDOOR.ssl
@@ -106,7 +106,7 @@ procedure use_obj_on_p_proc begin
    if (obj_pid(Tool) == PID_ELECTRONIC_LOCKPICKS or obj_pid(Tool) == PID_ELEC_LOCKPICK_MKII) then begin
       script_overrides;
 
-      if (Tool == PID_ELEC_LOCKPICK_MKII) then
+      if (obj_pid(Tool) == PID_ELEC_LOCKPICK_MKII) then
          Skills_Roll := roll_vs_skill(dude_obj, SKILL_LOCKPICK, -50);
 
       if (is_success(Skills_Roll)) then begin

--- a/Fallout2/Fallout1in2/Mapper/source/scripts/08mariposa/ARMDOOR.ssl
+++ b/Fallout2/Fallout1in2/Mapper/source/scripts/08mariposa/ARMDOOR.ssl
@@ -96,7 +96,7 @@ procedure use_obj_on_p_proc begin
    if (obj_pid(Item) == PID_ELECTRONIC_LOCKPICKS or obj_pid(Item) == PID_ELEC_LOCKPICK_MKII) then begin
       script_overrides;
 
-      if (Item == PID_ELEC_LOCKPICK_MKII) then
+      if (obj_pid(Item) == PID_ELEC_LOCKPICK_MKII) then
          Skill := roll_vs_skill(dude_obj, SKILL_LOCKPICK, -10);
 
       if (is_success(Skill)) then begin

--- a/Fallout2/Fallout1in2/Mapper/source/scripts/08mariposa/VCONDOOR.ssl
+++ b/Fallout2/Fallout1in2/Mapper/source/scripts/08mariposa/VCONDOOR.ssl
@@ -46,7 +46,7 @@ procedure use_obj_on_p_proc begin
    if (obj_pid(Item) == PID_ELECTRONIC_LOCKPICKS or obj_pid(Item) == PID_ELEC_LOCKPICK_MKII) then begin
       script_overrides;
 
-      if (Item == PID_ELEC_LOCKPICK_MKII) then
+      if (obj_pid(Item) == PID_ELEC_LOCKPICK_MKII) then
          test := roll_vs_skill(dude_obj, SKILL_LOCKPICK, -10);
 
       if (not(obj_is_locked(self_obj))) then begin


### PR DESCRIPTION
`VCONDOOR.SSL` probably needs additional review on lock difficulty. Before this PR it's -20 on bare skill (no item), 0 with lock picks with no additional bonus on mk ii. After this PR it will be -10 on mk ii which is obviously wrong.