### PR TITLE
Fix critical failure check

### DIFF
--- a/Fallout2/Fallout1in2/Mapper/source/scripts/08mariposa/VMONOWIR.ssl
+++ b/Fallout2/Fallout1in2/Mapper/source/scripts/08mariposa/VMONOWIR.ssl
@@ -60,7 +60,8 @@ procedure use_skill_on_p_proc
 begin
    if ((map_var(7) == 1) and (map_var(13) == 0)) then begin
       script_overrides;
-      if (dude_skill_success(SKILL_TRAPS, -20)) then begin
+      test := roll_vs_skill(dude_obj, SKILL_TRAPS, -20)
+      if (is_success(test)) then begin
          display_msg(message_str(SCRIPT_VMONOWIR, 104));
          set_map_var(13, 1);
          move_to(self_obj, 7000, 0);

--- a/Fallout2/Fallout1in2/Mapper/source/scripts/08mariposa/VMONOWIR.ssl
+++ b/Fallout2/Fallout1in2/Mapper/source/scripts/08mariposa/VMONOWIR.ssl
@@ -60,7 +60,7 @@ procedure use_skill_on_p_proc
 begin
    if ((map_var(7) == 1) and (map_var(13) == 0)) then begin
       script_overrides;
-      test := roll_vs_skill(dude_obj, SKILL_TRAPS, -20)
+      test := roll_vs_skill(dude_obj, SKILL_TRAPS, -20);
       if (is_success(test)) then begin
          display_msg(message_str(SCRIPT_VMONOWIR, 104));
          set_map_var(13, 1);


### PR DESCRIPTION
Fix critical failure code path not being reachable because `test` variable is never set.