### PR TITLE
Fix night healing cost

### DIFF
--- a/Fallout2/Fallout1in2/Mapper/source/scripts/03junktown/MORBID.ssl
+++ b/Fallout2/Fallout1in2/Mapper/source/scripts/03junktown/MORBID.ssl
@@ -495,7 +495,7 @@ procedure Morbid09 begin
       end
    end
    if night then begin
-      COST := COST * (3 / 2);
+      COST := COST * 3 / 2;
    end
    NMessage(DIAGNOSIS);
    call Morbid09a;


### PR DESCRIPTION
`3 / 2` evaluates to `1` leading to no markup, however it doesn't really change anything as doctor is not available at night.