### PR TITLE
Fix Kyle known flag not being set

### DIFF
--- a/Fallout2/Fallout1in2/Mapper/source/scripts/07bos/KYLE.ssl
+++ b/Fallout2/Fallout1in2/Mapper/source/scripts/07bos/KYLE.ssl
@@ -201,6 +201,7 @@ procedure goto12 begin
 end
 
 procedure goto13 begin
+   known := 1;
    Reply(137);
    NOption(138, goto02, 4);
    BOption(139, goto04, 4);


### PR DESCRIPTION
It only affects look at message ("You see: Kyle." vs. "You see a Knight.").