### PR TITLE
wm travel speed romve pathfinder

### DIFF
--- a/Fallout2/Fallout1in2/Mapper/source/scripts/GlobalScripts/gl_worldmap.ssl
+++ b/Fallout2/Fallout1in2/Mapper/source/scripts/GlobalScripts/gl_worldmap.ssl
@@ -282,7 +282,7 @@ variable terrain_time, time, skill;
    else begin
       terrain_time := 0.408; // 10h
    end
-   time := ((-0.0075717243419 * skill + 1.75717243419) * terrain_time) * (1 - dude_perk(PERK_pathfinder) * 0.25);
+   time := ((-0.0075717243419 * skill + 1.75717243419) * terrain_time);
 
    //debug("terrain_time: " + time);
    set_map_time_multi(time);


### PR DESCRIPTION
since the pathfinder perk in the vanilla game already decreases the ingame time passing while traveling on the wm its unnecessary to make its decrease player travel time aka increasing player travel speed
Also the perk description clearly states that it decreases the time passing and not increases player speed.