### PR TITLE
encounter rate

### DIFF
--- a/Fallout2/Fallout1in2/ddraw.ini
+++ b/Fallout2/Fallout1in2/ddraw.ini
@@ -275,8 +275,8 @@ WorldMapDelay2=63
 
 ;Set to 1 to enable Ray's patch to make world map encounter rate independent of your travel speed
 ;Higher values of WorldMapEncounterRate cause a slower encounter rate
-WorldMapEncounterFix=1
-WorldMapEncounterRate=30
+WorldMapEncounterFix=0
+WorldMapEncounterRate=0
 
 ;The number of slots available in the locations list panel of the world map
 ;Set to 0 to leave the default unchanged (i.e. 17). The maximum is 127


### PR DESCRIPTION
makes encounter rate dependend on wm travel speed again by deactivating rays patch, so that outdoorsman effects encounter rate through the new travel speed mechanic