### PR TITLE
Healer and Faster Healing perk description

### DIFF
--- a/Fallout2/Fallout1in2/mods/fo1_base/text/english/game/PERK.msg
+++ b/Fallout2/Fallout1in2/mods/fo1_base/text/english/game/PERK.msg
@@ -134,7 +134,7 @@
 {1105}{}{Your training in firearms and other ranged weapons has made you more deadly in ranged combat.  For each level of this Perk, you do +2 points of damage with ranged weapons.}
 {1106}{}{This Perk allows you to pull the trigger a little more faster, and still remain as accurate as before.  Each ranged weapon attack costs 1 AP less to perform.}
 {1107}{}{You are more likely to move before your opponents in combat, since your Sequence is +2 for each level of this Perk.}
-{1108}{}{With each level of this Perk, you will get a +1 bonus to your Healing Rate.  Thus you heal faster.}
+{1108}{}{With each level of this Perk, you will get a +2 bonus to your Healing Rate.  Thus you heal faster.}
 {1109}{}{You are more likely to cause Critical Hits in combat if you have this Perk.  Each level of More Criticals will get you a +5% chance to cause a critical hit.  This is a good thing.}
 {1110}{}{With the Night Vision Perk, you can see in the dark better.  Each level of this Perk will reduce the overall darkness level by 10%.}
 {1111}{}{You command attention by just walking into a room.  The initial reaction of another person is improved by 10% for each level of this Perk.}
@@ -146,7 +146,7 @@
 {1117}{}{You are a master of the outdoors.  This Perk confers the ability to survive in hostile environments.  You get a +20% bonus to Outdoorsman for survival purposes, for each level of this Perk.}
 {1118}{}{You have mastered one aspect of bartering - the ability to buy goods far cheaper than a normal person.  With this Perk, you get a 25% discount when purchasing items from a store or another trader.}
 {1119}{}{Each level of Educated will add +2 skill points when you gain a new experience level.  This Perk works best when purchased early in your adventure.}
-{1120}{}{The healing of bodies comes easier to you with this Perk.  Each level will add 2-5 more hit points healed when using the First Aid or Doctor skills.}
+{1120}{}{The healing of bodies comes easier to you with this Perk.  Each level will add 4-10 more hit points healed when using the First Aid or Doctor skills.}
 {1121}{}{You have the talent of finding money.  You will find additional money in random encounters in the desert.}
 {1122}{}{The critical hits you cause in combat are more devastating.  You gain a 20% bonus on the critical hit table, almost ensuring that more damage will be done.  This does not affect the chance to cause a critical hit.}
 {1123}{}{You have studied other human beings, giving you the inside knowledge of their emotional reaction to you.  You will see the reaction level of the person you are talking to, when involved in an indepth conversation.}


### PR DESCRIPTION
changed description of the Healer and Faster Healing perks in the english version to show the vanilla Fallout 2 bonuses that are applied since they havent been changed to better reflect what bonuses those perks offer.

Funny enough but the French and German translations show the correct Fallout 2 values that are actually applied.