### PR TITLE
Give Healer perk 2 ranks again

### DIFF
--- a/Fallout2/Fallout1in2/config/Perks.ini
+++ b/Fallout2/Fallout1in2/config/Perks.ini
@@ -159,7 +159,7 @@ Enable=1
 [1]
 Level=6
 
-; Bonus Move Tee
+; Bonus Move 
 [3]
 Ranks=3
 

--- a/Fallout2/Fallout1in2/config/Perks.ini
+++ b/Fallout2/Fallout1in2/config/Perks.ini
@@ -159,7 +159,7 @@ Enable=1
 [1]
 Level=6
 
-; Bonus Move
+; Bonus Move Tee
 [3]
 Ranks=3
 
@@ -192,10 +192,6 @@ Ranks=3
 [17]
 Level=9
 Skill1Mag=60
-
-; Healer
-[19]
-Rank=3
 
 ; Slayer
 [23]


### PR DESCRIPTION
Since it gives the (compared to Fallout 1) increased Fallout 2 bonus it makes sense to give its the default 2 ranks(I guess thats why the devs did it originally)