### PR TITLE
Fix Irwine typo to spell Irwin correctly

### DIFF
--- a/Fallout2/Fallout1in2/mods/fo1_base/text/english/dialog/IRWIN.msg
+++ b/Fallout2/Fallout1in2/mods/fo1_base/text/english/dialog/IRWIN.msg
@@ -43,8 +43,8 @@
 # Fo1in2:
 {2000}{}{First, right after leaving the Hub you will follow the main road eastwards for a few miles, past the old rail road station. Then circle down south, you will find the old Cooper farm (you can't miss it). Walk right past it, and then ... }
 {2001}{}{[More]}
-{2002}{}{[Irwine explains the directions in great detail. So much so, you're almost falling asleep. Minutes go by till you finally plotted the directions on your PipBoy]}
-# Floats, Irwine is back at his farm:
+{2002}{}{[Irwin explains the directions in great detail. So much so, you're almost falling asleep. Minutes go by till you finally plotted the directions on your PipBoy]}
+# Floats, Irwin is back at his farm:
 {2500}{}{Thank you for giving me my farm back.}
 {2501}{}{Thanks again.}
 {2502}{}{There is much work to do.}

--- a/Fallout2/Fallout1in2/mods/fo1_lang_french/text/french/dialog/IRWIN.msg
+++ b/Fallout2/Fallout1in2/mods/fo1_lang_french/text/french/dialog/IRWIN.msg
@@ -1,58 +1,58 @@
 {100}{}{Voici Irwin.}
-{101}{}{Nom d'un chien, tu peux pas me laisser tranquille ? J'ai assez de problèmes comme ça.}
-{102}{}{Des problèmes ? Je peux peut-être t'aider.}
-{103}{}{Comme si tu étais le seul à avoir des problèmes !}
+{101}{}{Nom d'un chien, tu peux pas me laisser tranquille ? J'ai assez de problÃ¨mes comme Ã§a.}
+{102}{}{Des problÃ¨mes ? Je peux peut-Ãªtre t'aider.}
+{103}{}{Comme si tu Ã©tais le seul Ã  avoir des problÃ¨mes !}
 {104}{}{C'est bon. Pas la peine de hurler.}
-{105}{}{Hmm... Je ne sais pas. T'as pas vraiment la carrure. Ecoute, pourquoi est-ce que tu ne repasserais pas quand t'auras un peu plus roulé ta bosse ?}
-{106}{}{C'est une tragédie, crois-moi. Rien n'est plus comme avant. J'ai une petite ferme en-dehors de la ville et il y a quelques jours, une bande de Pillards a débarqué de nulle part pour installer son campement chez moi. Ils ont tué mon âne Camus et m'ont menacé de mort si j'osais revenir.}
-{107}{}{Dis-moi où ça se trouve et je me charge du reste.}
-{108}{}{Malheureusement Irwin, j'ai des choses plus importantes à faire.}
-{109}{}{Vraiment, tu le ferais ? Tu sais, j'ose plus y remettre les pieds. S'il te plaît, reviens me dire quand je pourrai retourner sans risque chez moi.}
+{105}{}{Hmm... Je ne sais pas. T'as pas vraiment la carrure. Ecoute, pourquoi est-ce que tu ne repasserais pas quand t'auras un peu plus roulÃ© ta bosse ?}
+{106}{}{C'est une tragÃ©die, crois-moi. Rien n'est plus comme avant. J'ai une petite ferme en-dehors de la ville et il y a quelques jours, une bande de Pillards a dÃ©barquÃ© de nulle part pour installer son campement chez moi. Ils ont tuÃ© mon Ã¢ne Camus et m'ont menacÃ© de mort si j'osais revenir.}
+{107}{}{Dis-moi oÃ¹ Ã§a se trouve et je me charge du reste.}
+{108}{}{Malheureusement Irwin, j'ai des choses plus importantes Ã  faire.}
+{109}{}{Vraiment, tu le ferais ? Tu sais, j'ose plus y remettre les pieds. S'il te plaÃ®t, reviens me dire quand je pourrai retourner sans risque chez moi.}
 # 110 "beat it" means "leave"
-{110}{}{Ecoute, je crois t'avoir déjà demandé de me laisser tranquille. Débarrasse le plancher !}
-{111}{}{Je savais bien que tu te dégonflerais. C'est toujours la même chose dès qu'il s'agit des Pillards.}
-{112}{}{Alors, tu as pu donner une bonne leçon à ces Pillards ? Ma maison est à nouveau sûre ?}
+{110}{}{Ecoute, je crois t'avoir dÃ©jÃ  demandÃ© de me laisser tranquille. DÃ©barrasse le plancher !}
+{111}{}{Je savais bien que tu te dÃ©gonflerais. C'est toujours la mÃªme chose dÃ¨s qu'il s'agit des Pillards.}
+{112}{}{Alors, tu as pu donner une bonne leÃ§on Ã  ces Pillards ? Ma maison est Ã  nouveau sÃ»re ?}
 {113}{}{Y'a plus de danger.}
 {114}{}{Je n'ai pas encore eu le temps de m'en occuper.}
-{115}{}{Oh, je ne sais pas comment te remercier. Je n'ai pas grand chose à t'offrir mais tiens, prends ce fusil. Il appartenait à mon père, qui le tenait de son grand-père Rick. Tu en feras meilleur usage que moi.}
-{116}{}{Tu joues avec mes nerfs ou quoi ? Allez, ne joue pas à ça. Reviens me dire quand je pourrai retourner chez moi sans risque. Te le feras, dis ?}
-{117}{}{Merci. Merci de m'avoir aidé.}
+{115}{}{Oh, je ne sais pas comment te remercier. Je n'ai pas grand chose Ã  t'offrir mais tiens, prends ce fusil. Il appartenait Ã  mon pÃ¨re, qui le tenait de son grand-pÃ¨re Rick. Tu en feras meilleur usage que moi.}
+{116}{}{Tu joues avec mes nerfs ou quoi ? Allez, ne joue pas Ã  Ã§a. Reviens me dire quand je pourrai retourner chez moi sans risque. Te le feras, dis ?}
+{117}{}{Merci. Merci de m'avoir aidÃ©.}
 
 # Nimrod
-{200}{}{Tu reçois }
-{201}{}{ points d'expérience pour avoir sauvé la ferme d'Irwin.}
+{200}{}{Tu reÃ§ois }
+{201}{}{ points d'expÃ©rience pour avoir sauvÃ© la ferme d'Irwin.}
 
 #for Stupid characters
-{118}{}{Grééé ?}
-{119}{}{Ecoute, j'ai pas de temps pour les idiots. Reviens quand tu auras allumé la lumière à tous les étages.}
+{118}{}{GrÃ©Ã©Ã© ?}
+{119}{}{Ecoute, j'ai pas de temps pour les idiots. Reviens quand tu auras allumÃ© la lumiÃ¨re Ã  tous les Ã©tages.}
 {120}{}{Uh Huh, Uh Huh, Uh Huh. je l'ai faiit.}
 {121}{}{Moi pas fini.}
 {123}{}{Pas trouver ferme. Toi montrer ?}
 {403}{}{Merssii !}
 
-{300}{}{Crève !}
+{300}{}{CrÃ¨ve !}
 {301}{}{Ramenez moi son cadavre !}
-{302}{}{Dis adieu à la vie !}
+{302}{}{Dis adieu Ã  la vie !}
 {303}{}{Je vais te trouer comme un fromage suisse !}
 
 # Sduibek
-{400}{}{Pas encore. Peux tu me redire comment se rendre là bas ?}
-{401}{}{Bien sur mais dépêche toi s'il te plait.}
+{400}{}{Pas encore. Peux tu me redire comment se rendre lÃ  bas ?}
+{401}{}{Bien sur mais dÃ©pÃªche toi s'il te plait.}
 {402}{}{Merci.}
 
 # Fo1in2:
-{2000}{}{D'abord, juste après avoir quitté le Centre, vous suivrez la route à l'Est pour quelques kilomètres, après la gare ferroviaire. Bifurquez vers le Sud, et vous tomberez sur la ferme du vieux Cooper (vous pouvez pas la rater). Passez là et ensuite... }
+{2000}{}{D'abord, juste aprÃ¨s avoir quittÃ© le Centre, vous suivrez la route Ã  l'Est pour quelques kilomÃ¨tres, aprÃ¨s la gare ferroviaire. Bifurquez vers le Sud, et vous tomberez sur la ferme du vieux Cooper (vous pouvez pas la rater). Passez lÃ  et ensuite... }
 {2001}{}{[Continue]}
-{2002}{}{[Irwin t'explique la route à suivre en grands détails. Tellement, que tu dois lutter contre le sommeil. Après quelques minutes, tu réussi à ajouter l'emplacement sur ton PipBoy]}
-# Floats, Irwine is back at his farm:
+{2002}{}{[Irwin t'explique la route Ã  suivre en grands dÃ©tails. Tellement, que tu dois lutter contre le sommeil. AprÃ¨s quelques minutes, tu rÃ©ussi Ã  ajouter l'emplacement sur ton PipBoy]}
+# Floats, Irwin is back at his farm:
 {2500}{}{Merci de m'avoir rendu ma ferme.}
 {2501}{}{Encore merci.}
-{2502}{}{Il y a tellement de travail à faire.}
-{2503}{}{Ces pillards ont ruiné ma table.}
-{2504}{}{Oh mon dieu, mais regarde moi ça ?}
+{2502}{}{Il y a tellement de travail Ã  faire.}
+{2503}{}{Ces pillards ont ruinÃ© ma table.}
+{2504}{}{Oh mon dieu, mais regarde moi Ã§a ?}
 {2505}{}{Bonjour.}
-{2506}{}{Vous êtes toujours là ?}
-{2507}{}{J'espère que vous vous servirez de cette arme à bon escient !}
+{2506}{}{Vous Ãªtes toujours lÃ  ?}
+{2507}{}{J'espÃ¨re que vous vous servirez de cette arme Ã  bon escient !}
 {2508}{}{Ca va me prendre du temps pour refaire tourner ma ferme.}
 {2509}{}{Content de te voir.}
-{2510}{}{Comment ça va ?}
+{2510}{}{Comment Ã§a va ?}

--- a/Fallout2/Fallout1in2/mods/fo1_lang_german/text/german/dialog/IRWIN.msg
+++ b/Fallout2/Fallout1in2/mods/fo1_lang_german/text/german/dialog/IRWIN.msg
@@ -1,59 +1,59 @@
 {100}{}{Du siehst Irwin.}
 {101}{}{Ach Junge, kannst du mich nicht in Ruhe lassen? Ich hab' schon genug Probleme.}
 {102}{}{Probleme? Vielleicht kann ich helfen.}
-{103}{}{Als ob nur du Probleme hättest.}
-{104}{}{Okay, okay. Musst mich ja nicht gleich anbrüllen.}
-{105}{}{Hmm ... Ich weiß nicht. Ich brauch' 'ne andere Sorte Held als dich. Hör mal, warum kommst du nicht wieder, wenn du ein bisschen Erfahrung gesammelt hast?}
-{106}{}{Es ist eine Tragödie, kannst du mir glauben. Nichts ist so, wie es mal war. Ich habe 'nen kleinen Bauernhof vor der Stadt, und vor ein paar Tagen ist ein Haufen Raiders aufgekreuzt und benutzt mein Heim jetzt als Lager. Sie haben Pugsley, meinen Esel, getötet und mir gedroht, dass sie mit mir dasselbe machen, wenn ich es wage zurückzukehren.}
-{107}{}{Sag mir wo, und ich kümmer' mich um den Rest.}
+{103}{}{Als ob nur du Probleme hÃ¤ttest.}
+{104}{}{Okay, okay. Musst mich ja nicht gleich anbrÃ¼llen.}
+{105}{}{Hmm ... Ich weiÃŸ nicht. Ich brauch' 'ne andere Sorte Held als dich. HÃ¶r mal, warum kommst du nicht wieder, wenn du ein bisschen Erfahrung gesammelt hast?}
+{106}{}{Es ist eine TragÃ¶die, kannst du mir glauben. Nichts ist so, wie es mal war. Ich habe 'nen kleinen Bauernhof vor der Stadt, und vor ein paar Tagen ist ein Haufen Raiders aufgekreuzt und benutzt mein Heim jetzt als Lager. Sie haben Pugsley, meinen Esel, getÃ¶tet und mir gedroht, dass sie mit mir dasselbe machen, wenn ich es wage zurÃ¼ckzukehren.}
+{107}{}{Sag mir wo, und ich kÃ¼mmer' mich um den Rest.}
 {108}{}{Tut mir leid, Irwin, aber ich habe Wichtigeres zu tun.}
-{109}{}{Wirklich, würdest du das tun? Weißt du, ich trau' mich nicht mehr zurück. Warum kommst du nicht wieder und sagst mir, wenn ich wieder sicher nach Hause kann?}
-{110}{}{Hör zu, du Typ! Ich hab' von Anfang an gesagt, dass du mich in Ruhe lassen sollst. Jetzt hau ab!}
+{109}{}{Wirklich, wÃ¼rdest du das tun? WeiÃŸt du, ich trau' mich nicht mehr zurÃ¼ck. Warum kommst du nicht wieder und sagst mir, wenn ich wieder sicher nach Hause kann?}
+{110}{}{HÃ¶r zu, du Typ! Ich hab' von Anfang an gesagt, dass du mich in Ruhe lassen sollst. Jetzt hau ab!}
 {111}{}{Ich hab' gewusst, dass du kneifst. Jeder kneift vor den Raiders.}
 {112}{}{Hast du den Raiders eine Lektion erteilt? Ist mein Zuhause wieder sicher?}
 {113}{}{Aber klar doch, Kumpel!}
-{114}{}{Ich hatte noch nicht die Zeit, mich darum zu kümmern.}
-{115}{}{Oh, herzlichsten Dank. Ich kann dir leider keine Reichtümer schenken, aber da, nimm diese Pistole als Belohnung dafür, dass du mein Heim gerettet hast.}
-{116}{}{Du willst mich auf den Arm nehmen, stimmt's? Spiel bitte nicht mit mir. Komm zurück und sag's mir, wenn ich wieder sicher nach Hause kann, okay?}
+{114}{}{Ich hatte noch nicht die Zeit, mich darum zu kÃ¼mmern.}
+{115}{}{Oh, herzlichsten Dank. Ich kann dir leider keine ReichtÃ¼mer schenken, aber da, nimm diese Pistole als Belohnung dafÃ¼r, dass du mein Heim gerettet hast.}
+{116}{}{Du willst mich auf den Arm nehmen, stimmt's? Spiel bitte nicht mit mir. Komm zurÃ¼ck und sag's mir, wenn ich wieder sicher nach Hause kann, okay?}
 {117}{}{Vielen Dank, dass du mir hilfst.}
 
 # Nimrod
-{200}{}{Du erhältst }
-{201}{}{ Erfahrungspunkte dafür, dass du Irwin's Farm gerettet hast.}
+{200}{}{Du erhÃ¤ltst }
+{201}{}{ Erfahrungspunkte dafÃ¼r, dass du Irwin's Farm gerettet hast.}
 
 #for Stupid characters
 {118}{}{Grunk?}
-{119}{}{Hör zu, ich habe keine Zeit für Idioten. Komm zurück, wenn du schlauer bist.}
-{120}{}{Äh. Häh. Äh. Häh. Getan.}
+{119}{}{HÃ¶r zu, ich habe keine Zeit fÃ¼r Idioten. Komm zurÃ¼ck, wenn du schlauer bist.}
+{120}{}{Ã„h. HÃ¤h. Ã„h. HÃ¤h. Getan.}
 {121}{}{Ich noch nichts gemacht.}
 {123}{}{Nicht finde Farm. Du zeigen?}
 {403}{}{Dank-e!}
 
 # the Raiders at his farm
-{300}{}{Tritt vor deinen Schöpfer!}
+{300}{}{Tritt vor deinen SchÃ¶pfer!}
 {301}{}{Macht ihn platt!}
-{302}{}{Das war dein letztes Käsebrot!}
-{303}{}{Gleich siehst du aus wie Schweizer Käse, voller Löcher!}
+{302}{}{Das war dein letztes KÃ¤sebrot!}
+{303}{}{Gleich siehst du aus wie Schweizer KÃ¤se, voller LÃ¶cher!}
 
 # TODO: TRANSLATE
 # Sduibek
-{400}{}{Nicht ganz. Könntest du mir erneut beschreiben wie ich hin komme?}
-{401}{}{Mache ich, aber beeile dich bitte. Ich will entlich zurück nach Hause.}
+{400}{}{Nicht ganz. KÃ¶nntest du mir erneut beschreiben wie ich hin komme?}
+{401}{}{Mache ich, aber beeile dich bitte. Ich will entlich zurÃ¼ck nach Hause.}
 {402}{}{Danke.}
 
 # Fo1in2:
-{2000}{}{Gleich nach dem Verlassen des Hubs folgst du zunächst der Hauptstraße einige Kilometer nach Osten, vorbei am alten Bahnhof. Dreh' dann ab nach Süden und du findest die alte Cooper Farm. Kannst sie wirklich nicht verfehlen. Geh' direkt dran vorbei, und dann... }
+{2000}{}{Gleich nach dem Verlassen des Hubs folgst du zunÃ¤chst der HauptstraÃŸe einige Kilometer nach Osten, vorbei am alten Bahnhof. Dreh' dann ab nach SÃ¼den und du findest die alte Cooper Farm. Kannst sie wirklich nicht verfehlen. Geh' direkt dran vorbei, und dann... }
 {2001}{}{[MEHR]}
-{2002}{}{[Irwin erklärt die Anweisungen derart detailliert, dass du fast einschläfst. Einige Minuten vergehen, bis du endlich die Anweisungen auf den PipBoy übertragen hast.]}
-# Floats, Irwine is back at his farm:
-{2500}{}{Danke, dass du mir meine Farm zurückgegeben hast.}
+{2002}{}{[Irwin erklÃ¤rt die Anweisungen derart detailliert, dass du fast einschlÃ¤fst. Einige Minuten vergehen, bis du endlich die Anweisungen auf den PipBoy Ã¼bertragen hast.]}
+# Floats, Irwin is back at his farm:
+{2500}{}{Danke, dass du mir meine Farm zurÃ¼ckgegeben hast.}
 {2501}{}{Danke noch einmal.}
 {2502}{}{Es gibt viel zu tun.}
-{2503}{}{Die Raider haben meinen Tisch verwüstet.}
+{2503}{}{Die Raider haben meinen Tisch verwÃ¼stet.}
 {2504}{}{Oh Gott, sieh dir das an!}
 {2505}{}{Hallo.}
 {2506}{}{Du bist immer noch hier?}
-{2507}{}{Ich hoffe du benutzt die Waffe für einen guten Zweck!}
+{2507}{}{Ich hoffe du benutzt die Waffe fÃ¼r einen guten Zweck!}
 {2508}{}{Es wird eine Weile dauern, bis meine Farm wieder was abwirft. *seufz*}
-{2509}{}{Schön dich zu sehen.}
+{2509}{}{SchÃ¶n dich zu sehen.}
 {2510}{}{Wie geht's?}


### PR DESCRIPTION
Irwine typos appear in IRWIN.msg in English dialog (twice), French dialog and German dialog. These 3 commits fix the typos so Irwin is always spelled Irwin.