### PR TITLE
fix undat.sh - quote master_dat to handle path spaces

### DIFF
--- a/Tools/UndatCLI/undat.sh
+++ b/Tools/UndatCLI/undat.sh
@@ -19,7 +19,7 @@ data_dir="$root_dir/data"
 dat2="wine $root_dir/dat2.exe"
 undat_list="$root_dir/undat_files.txt"
 
-if ! $dat2 l $master_dat > /dev/null 2>&1; then
+if ! $dat2 l "${master_dat}" > /dev/null 2>&1; then
   echo "Error: can't read Fallout 1's master.dat."
   exit 1
 fi


### PR DESCRIPTION
When the path to `master.dat` contains space (for example the GOG version does), the way how it is passed to `dat2.exe` does not work. Quoting the path fixes the issue.

before:

```
wine ./dat2.exe x -d ./data /path/to/GOG Games/Fallout/master.dat @./undat_files.txt
                                        ^path is considered to end here
```

after:
```
wine ./dat2.exe x -d ./data "/path/to/GOG Games/Fallout/master.dat" @./undat_files.txt
```

This should fix #326 as well